### PR TITLE
Add TAPR student/staff profile enrichment for campuses

### DIFF
--- a/teadata/load_data2.py
+++ b/teadata/load_data2.py
@@ -151,6 +151,22 @@ def run_enrichments(repo: DataEngine) -> None:
     except Exception as e:
         print(f"[enrich] campus_peims_financials failed: {e}")
 
+    try:
+        yr_tapr, n_tapr = enrich_campuses_from_config(
+            repo,
+            CFG,
+            "campus_tapr_student_staff_profile",
+            YEAR,
+            select=None,
+            rename=None,
+            reader_kwargs=None,
+        )
+        print(
+            f"Enriched {n_tapr} campuses from TAPR student/staff profile {yr_tapr}"
+        )
+    except Exception as e:
+        print(f"[enrich] campus_tapr_student_staff_profile failed: {e}")
+
 
 # ------------------ Repo snapshot cache (warm start) ------------------
 def _file_mtime(p: str | Path) -> float:
@@ -250,6 +266,7 @@ def _compute_extra_signature() -> dict:
             "campus_accountability",
             "charter_reference",
             "campus_peims_financials",
+            "campus_tapr_student_staff_profile",
             "campus_transfer_reports",
         ):
             try:


### PR DESCRIPTION
## Summary
- allow campus enrichment to default to all available columns when no explicit selection is provided
- register and wire up the campus TAPR student/staff profile enrichment so every column is attached to campus metadata
- include the new dataset in the snapshot cache signature to invalidate warm starts when the source changes

## Testing
- pytest *(fails: geopandas >= 0.14 is required but not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68df785a0d9083319b84cd488cadd633