### PR TITLE
Add TAPR student/staff profile and historical enrollment enrichment for campuses

### DIFF
--- a/teadata/enrichment/campuses.py
+++ b/teadata/enrichment/campuses.py
@@ -121,22 +121,32 @@ def _apply_campus_accountability(
             f"[enrich:{dataset}] canonical campus numbers -> valid_rows={valid_rows} unique_keys={unique_keys}"
         )
 
-    if not select:
-        raise ValueError(
-            "campus enrichment requires an explicit `select` collection of column names"
-        )
-
-    use_cols = list(select)
-    missing = [c for c in use_cols if c not in df.columns]
-    if missing:
-        if _profile_enabled():
-            _debug(
-                f"[enrich:{dataset}] missing columns after rename: {', '.join(sorted(missing))}"
+    if select is None:
+        use_cols = [c for c in df.columns if c != "campus_number"]
+    else:
+        missing: list[str] = []
+        use_cols = []
+        for col in select:
+            if col == "campus_number":
+                continue
+            if col not in df.columns:
+                missing.append(col)
+                continue
+            if col not in use_cols:
+                use_cols.append(col)
+        if missing:
+            if _profile_enabled():
+                _debug(
+                    f"[enrich:{dataset}] missing columns after rename: {', '.join(sorted(missing))}"
+                )
+            raise KeyError(
+                "campus enrichment missing expected columns after rename: "
+                + ", ".join(sorted(missing))
             )
-        raise KeyError(
-            "campus enrichment missing expected columns after rename: "
-            + ", ".join(sorted(missing))
-        )
+        if not use_cols:
+            raise ValueError(
+                "campus enrichment requires a non-empty `select` collection of column names"
+            )
 
     for c in use_cols:
         if c in df.columns:
@@ -414,6 +424,38 @@ class CampusPEIMSFinancials(Enricher):
             year,
             select=DEFAULT_PEIMS_FINANCIAL_COLUMNS,
             rename=None,
+            reader_kwargs=None,
+        )
+        return {"updated": updated, "year": yr}
+
+
+@enricher("campus_tapr_student_staff_profile")
+class CampusTaprStudentStaffProfile(Enricher):
+    def apply(self, repo, cfg_path: str, year: int) -> Dict[str, Any]:
+        yr, updated = _apply_campus_accountability(
+            repo,
+            cfg_path,
+            "campus_tapr_student_staff_profile",
+            year,
+            select=None,
+            rename=None,
+            aliases=None,
+            reader_kwargs=None,
+        )
+        return {"updated": updated, "year": yr}
+
+
+@enricher("campus_tapr_historical_enrollment")
+class CampusTaprHistoricalEnrollment(Enricher):
+    def apply(self, repo, cfg_path: str, year: int) -> Dict[str, Any]:
+        yr, updated = _apply_campus_accountability(
+            repo,
+            cfg_path,
+            "campus_tapr_historical_enrollment",
+            year,
+            select=None,
+            rename=None,
+            aliases=None,
             reader_kwargs=None,
         )
         return {"updated": updated, "year": yr}

--- a/teadata/load_data2.py
+++ b/teadata/load_data2.py
@@ -151,6 +151,38 @@ def run_enrichments(repo: DataEngine) -> None:
     except Exception as e:
         print(f"[enrich] campus_peims_financials failed: {e}")
 
+    try:
+        yr_tapr, n_tapr = enrich_campuses_from_config(
+            repo,
+            CFG,
+            "campus_tapr_student_staff_profile",
+            YEAR,
+            select=None,
+            rename=None,
+            reader_kwargs=None,
+        )
+        print(
+            f"Enriched {n_tapr} campuses from TAPR student/staff profile {yr_tapr}"
+        )
+    except Exception as e:
+        print(f"[enrich] campus_tapr_student_staff_profile failed: {e}")
+
+    try:
+        yr_hist, n_hist = enrich_campuses_from_config(
+            repo,
+            CFG,
+            "campus_tapr_historical_enrollment",
+            YEAR,
+            select=None,
+            rename=None,
+            reader_kwargs=None,
+        )
+        print(
+            f"Enriched {n_hist} campuses from TAPR historical enrollment {yr_hist}"
+        )
+    except Exception as e:
+        print(f"[enrich] campus_tapr_historical_enrollment failed: {e}")
+
 
 # ------------------ Repo snapshot cache (warm start) ------------------
 def _file_mtime(p: str | Path) -> float:
@@ -250,6 +282,8 @@ def _compute_extra_signature() -> dict:
             "campus_accountability",
             "charter_reference",
             "campus_peims_financials",
+            "campus_tapr_student_staff_profile",
+            "campus_tapr_historical_enrollment",
             "campus_transfer_reports",
         ):
             try:

--- a/teadata/teadata_sources.yaml
+++ b/teadata/teadata_sources.yaml
@@ -37,6 +37,9 @@ data_sources:
   campus_tapr_student_staff_profile:
     2024: data/tapr/CAMPPROF_2023-2024_FINAL.xlsx
     latest: 2024
+  campus_tapr_historical_enrollment:
+    2024: data/tapr/CAMPENR_2023-2024_FINAL.xlsx
+    latest: 2024
 
 spatial:
   districts:
@@ -55,6 +58,7 @@ schema:
     campus_transfer_reports: ["csv"]
     campus_peims_financials: ["csv"]
     campus_tapr_student_staff_profile: ["xlsx"]
+    campus_tapr_historical_enrollment: ["xlsx"]
   spatial:
     districts: ["geojson","gpkg","parquet"]
     campuses: ["geojson","gpkg","parquet"]


### PR DESCRIPTION
## Summary
- allow campus enrichment to default to all available columns when no explicit selection is provided
- register and wire up the campus TAPR student/staff profile enrichment so every column is attached to campus metadata
- include the new dataset in the snapshot cache signature to invalidate warm starts when the source changes
- register the TAPR historical enrollment enrichment so every column is added to campus metadata and include the dataset in the config and cache signature

## Testing
- pytest *(fails: geopandas >= 0.14 is required but not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68df785a0d9083319b84cd488cadd633