### PR TITLE
Add planned closure enrichment for campuses

### DIFF
--- a/teadata/classes.py
+++ b/teadata/classes.py
@@ -583,6 +583,8 @@ class Campus:
         except Exception:
             out["total_unmasked_charter_transfers_out"] = None
 
+        out["planned_closure"] = self.planned_closure
+
         if include_meta and isinstance(self.meta, dict):
             for k, v in self.meta.items():
                 if k not in out:
@@ -607,6 +609,24 @@ class Campus:
     @property
     def campus_number_canon(self) -> Optional[str]:
         return self._campus_number_canon
+
+    @property
+    def planned_closure(self) -> Optional[dict[str, Any]]:
+        meta = getattr(self, "meta", None)
+        if isinstance(meta, dict):
+            val = meta.get("planned_closure")
+            if isinstance(val, dict):
+                return val
+        return None
+
+    @planned_closure.setter
+    def planned_closure(self, value: Optional[dict[str, Any]]):
+        if getattr(self, "meta", None) is None or not isinstance(self.meta, dict):
+            self.meta = {}
+        if value is None:
+            self.meta.pop("planned_closure", None)
+        else:
+            self.meta["planned_closure"] = value
 
     @property
     def percent_enrollment_change(self) -> float:

--- a/teadata/load_data.py
+++ b/teadata/load_data.py
@@ -147,7 +147,11 @@ def _compute_extra_signature() -> dict:
     # Resolved data sources that affect enrichment
     try:
         cfg = load_config(CFG)
-        for ds in ("accountability", "campus_accountability"):
+        for ds in (
+            "accountability",
+            "campus_accountability",
+            "campus_planned_closures",
+        ):
             try:
                 _, p = cfg.resolve(ds, YEAR, section="data_sources")
                 sig[f"ds:{ds}"] = _safe_path_or_url_signature(p)


### PR DESCRIPTION
## Summary
- add a specialized enrichment path for the campus_planned_closures dataset that normalizes column names and records the resolved year
- expose planned closure details on Campus objects and include them in serialized output
- ensure snapshot cache signatures consider the planned closures dataset

## Testing
- python -m compileall teadata

------
https://chatgpt.com/codex/tasks/task_e_68e2871a394483319c825ddaecd5db69